### PR TITLE
Feature/#7 스케줄 api 구현 중 스케줄 서비스 작성

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -22,6 +22,8 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+	implementation 'org.springframework.boot:spring-boot-starter-data-rest'
+	implementation 'org.springframework.data:spring-data-rest-hal-explorer'
 	compileOnly 'org.projectlombok:lombok'
 	developmentOnly 'org.springframework.boot:spring-boot-devtools'
 	runtimeOnly 'mysql:mysql-connector-java'

--- a/src/main/java/com/example/study/calendarproject/config/SecurityConfig.java
+++ b/src/main/java/com/example/study/calendarproject/config/SecurityConfig.java
@@ -1,0 +1,18 @@
+package com.example.study.calendarproject.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.web.SecurityFilterChain;
+
+@Configuration
+public class SecurityConfig {
+
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        return http
+                .authorizeHttpRequests(auth -> auth.anyRequest().permitAll())
+                .formLogin().and()
+                .build();
+    }
+}

--- a/src/main/java/com/example/study/calendarproject/dto/ScheduleDto.java
+++ b/src/main/java/com/example/study/calendarproject/dto/ScheduleDto.java
@@ -1,0 +1,55 @@
+package com.example.study.calendarproject.dto;
+
+import com.example.study.calendarproject.domain.Schedule;
+import com.example.study.calendarproject.domain.constant.Category;
+import com.example.study.calendarproject.domain.constant.RepeatOption;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+public class ScheduleDto {
+    Long id;
+    String name;
+    String location;
+    Category category;
+    LocalDateTime start_time;
+    LocalDateTime end_time;
+    String description;
+    RepeatOption repeatOption;
+
+    protected ScheduleDto() {
+    }
+
+    private ScheduleDto(Long id, String name, String location, Category category, LocalDateTime start_time, LocalDateTime end_time, String description, RepeatOption repeatOption) {
+        this.id = id;
+        this.name = name;
+        this.location = location;
+        this.category = category;
+        this.start_time = start_time;
+        this.end_time = end_time;
+        this.description = description;
+        this.repeatOption = repeatOption;
+    }
+
+    public static ScheduleDto of(Long id, String name, String location, Category category, LocalDateTime start_time, LocalDateTime end_time, String description, RepeatOption repeatOption) {
+        return new ScheduleDto(id, name, location, category, start_time, end_time, description, repeatOption);
+    }
+
+    public static ScheduleDto from(Schedule entity) {
+        return new ScheduleDto(
+                entity.getId(),
+                entity.getName(),
+                entity.getLocation(),
+                entity.getCategory(),
+                entity.getStart_time(),
+                entity.getEnd_time(),
+                entity.getDescription(),
+                entity.getRepeatOption()
+        );
+    }
+
+    public Schedule toEntity() {
+        return Schedule.of(name, location, category, start_time, end_time, description, repeatOption);
+    }
+}

--- a/src/main/java/com/example/study/calendarproject/dto/ScheduleDto.java
+++ b/src/main/java/com/example/study/calendarproject/dto/ScheduleDto.java
@@ -22,6 +22,7 @@ public class ScheduleDto {
     }
 
     private ScheduleDto(Long id, String name, String location, Category category, LocalDateTime start_time, LocalDateTime end_time, String description, RepeatOption repeatOption) {
+        validateDateTime(start_time, end_time);
         this.id = id;
         this.name = name;
         this.location = location;
@@ -51,5 +52,10 @@ public class ScheduleDto {
 
     public Schedule toEntity() {
         return Schedule.of(name, location, category, start_time, end_time, description, repeatOption);
+    }
+
+    private void validateDateTime(LocalDateTime start_time, LocalDateTime end_time) {
+        if(start_time.isAfter(end_time))
+            throw new IllegalArgumentException("끝나는 시간이 시작 시간보다 빠를 수는 없습니다.");
     }
 }

--- a/src/main/java/com/example/study/calendarproject/dto/ScheduleDto.java
+++ b/src/main/java/com/example/study/calendarproject/dto/ScheduleDto.java
@@ -54,6 +54,7 @@ public class ScheduleDto {
         return Schedule.of(name, location, category, start_time, end_time, description, repeatOption);
     }
 
+    //스케줄이 생성될때 확인하는 메서드인데 나중에 ScheduleRequest 클래스 만들어서 거기로 옮길 예정 (DTO는 Getter Setter만 가능하다..)
     private void validateDateTime(LocalDateTime start_time, LocalDateTime end_time) {
         if(start_time.isAfter(end_time))
             throw new IllegalArgumentException("끝나는 시간이 시작 시간보다 빠를 수는 없습니다.");

--- a/src/main/java/com/example/study/calendarproject/repository/ScheduleRepository.java
+++ b/src/main/java/com/example/study/calendarproject/repository/ScheduleRepository.java
@@ -2,6 +2,8 @@ package com.example.study.calendarproject.repository;
 
 import com.example.study.calendarproject.domain.Schedule;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.rest.core.annotation.RepositoryRestResource;
 
+@RepositoryRestResource
 public interface ScheduleRepository extends JpaRepository<Schedule, Long> {
 }

--- a/src/main/java/com/example/study/calendarproject/service/ScheduleService.java
+++ b/src/main/java/com/example/study/calendarproject/service/ScheduleService.java
@@ -4,10 +4,14 @@ import com.example.study.calendarproject.domain.Schedule;
 import com.example.study.calendarproject.dto.ScheduleDto;
 import com.example.study.calendarproject.repository.ScheduleRepository;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import javax.persistence.EntityNotFoundException;
 
+
+@Slf4j
 @RequiredArgsConstructor
 @Transactional
 @Service
@@ -15,19 +19,42 @@ public class ScheduleService {
 
     private final ScheduleRepository scheduleRepository;
 
-    @Transactional(readOnly = true)
-    public Schedule getSchedule(Long scheduleId) {
-        return null;
-    }
-
     public Schedule saveSchedule(ScheduleDto dto) {
-        return null;
+        return scheduleRepository.save(dto.toEntity());
     }
 
-    public void updateSchedule(ScheduleDto Schedule) {
+    public void updateSchedule(Long scheduleId, ScheduleDto dto) {
+        try {
+            Schedule schedule = scheduleRepository.getReferenceById(scheduleId);
+
+            if (dto.getName() != null) {
+                schedule.setName(dto.getName());
+            }
+            if (dto.getLocation() != null) {
+                schedule.setLocation(dto.getLocation());
+            }
+            if (dto.getCategory() != null) {
+                schedule.setCategory(dto.getCategory());
+            }
+            if (dto.getStart_time() != null) {
+                schedule.setStart_time(dto.getStart_time());
+            }
+            if (dto.getEnd_time() != null) {
+                schedule.setEnd_time(dto.getEnd_time());
+            }
+            if (dto.getDescription() != null) {
+                schedule.setDescription(dto.getDescription());
+            }
+            if (dto.getRepeatOption() != null)
+                schedule.setRepeatOption(dto.getRepeatOption());
+        } catch (EntityNotFoundException e) {
+            log.warn("스케줄 업데이트 실패. 스케줄을 수정하는데 필요한 정보를 찾을 수 없습니다.");
+        }
+
     }
 
     public void deleteSchedule(Long scheduleId) {
+        scheduleRepository.deleteById(scheduleId);
     }
 
 }

--- a/src/main/java/com/example/study/calendarproject/service/ScheduleService.java
+++ b/src/main/java/com/example/study/calendarproject/service/ScheduleService.java
@@ -1,0 +1,33 @@
+package com.example.study.calendarproject.service;
+
+import com.example.study.calendarproject.domain.Schedule;
+import com.example.study.calendarproject.dto.ScheduleDto;
+import com.example.study.calendarproject.repository.ScheduleRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+
+@RequiredArgsConstructor
+@Transactional
+@Service
+public class ScheduleService {
+
+    private final ScheduleRepository scheduleRepository;
+
+    @Transactional(readOnly = true)
+    public Schedule getSchedule(Long scheduleId) {
+        return null;
+    }
+
+    public Schedule saveSchedule(ScheduleDto dto) {
+        return null;
+    }
+
+    public void updateSchedule(ScheduleDto Schedule) {
+    }
+
+    public void deleteSchedule(Long scheduleId) {
+    }
+
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -23,3 +23,7 @@ spring:
       hibernate.default_batch_fetch_size: 100
   h2.console.enabled: true
   sql.init.mode: always
+
+  data.rest:
+    base-path: /api
+    detection-strategy: annotated

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -16,7 +16,9 @@ insert into users(user_id, email, nickname, password) values
 insert into schedule(id, name, category, description, start_time, end_time, location, repeat_option) values
     (1, 'Backend Study', 'STUDY', 'backend study gogo', '2022-10-12 16:30:00', '2022-10-12 18:30:00', 'blindmelon', 'WEEK')
 ;
-
+insert into schedule(id, name, category, description, start_time, end_time, location, repeat_option) values
+    (2, 'Open Session', 'STUDY', '정기 스터디 모임 활동', '2022-11-20 16:30:00', '2022-11-20 19:30:00', '경대 북문 블라인드 멜론', 'WEEK')
+;
 -- plan 추가
 insert into plan(id, schedule_id, user_id) values
     (1, 1, 'a')

--- a/src/test/java/com/example/study/calendarproject/controller/DataRestTest.java
+++ b/src/test/java/com/example/study/calendarproject/controller/DataRestTest.java
@@ -1,0 +1,52 @@
+package com.example.study.calendarproject.controller;
+
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import javax.transaction.Transactional;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@Disabled
+@DisplayName("Data REST - API 테스트")
+@Transactional
+@AutoConfigureMockMvc
+@SpringBootTest
+public class DataRestTest {
+
+    private final MockMvc mvc;
+
+    public DataRestTest(@Autowired MockMvc mvc) {
+        this.mvc = mvc;
+    }
+
+    @DisplayName("[api] 스케줄 리스트 조회")
+    @Test
+    void givenNothing_whenRequesting_thenReturnsSchedulesJsonResponse() throws Exception {
+        // Given
+
+        // When & Then
+        mvc.perform(get("/api/schedules"))
+                .andExpect(status().isOk())
+                .andExpect(content().contentType(MediaType.valueOf("application/Hal+json")));
+    }
+
+    @DisplayName("[api] 스케줄 단건 조회")
+    @Test
+    void givenNothing_whenRequesting_thenReturnsScheduleJsonResponse() throws Exception {
+        // Given
+
+        // When & Then
+        mvc.perform(get("/api/schedules/1"))
+                .andExpect(status().isOk())
+                .andExpect(content().contentType(MediaType.valueOf("application/Hal+json")));
+    }
+}

--- a/src/test/java/com/example/study/calendarproject/dto/ScheduleDtoTest.java
+++ b/src/test/java/com/example/study/calendarproject/dto/ScheduleDtoTest.java
@@ -1,0 +1,29 @@
+package com.example.study.calendarproject.dto;
+
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowable;
+import static org.junit.jupiter.api.Assertions.*;
+
+class ScheduleDtoTest {
+
+    @Test
+    void validateDateTime() {
+        LocalDateTime start_time = LocalDateTime.of(2022, 11, 25, 16, 30);
+        LocalDateTime end_time = LocalDateTime.of(2022, 11, 24, 16, 30);
+
+        Throwable t = catchThrowable(() ->validateDateTime(start_time, end_time));
+        assertThat(t)
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("끝나는 시간이 시작 시간보다 빠를 수는 없습니다.");
+    }
+
+
+    void validateDateTime(LocalDateTime start_time, LocalDateTime end_time) {
+        if (start_time.isAfter(end_time))
+            throw new IllegalArgumentException("끝나는 시간이 시작 시간보다 빠를 수는 없습니다.");
+    }
+}

--- a/src/test/java/com/example/study/calendarproject/service/ScheduleServiceTest.java
+++ b/src/test/java/com/example/study/calendarproject/service/ScheduleServiceTest.java
@@ -1,0 +1,124 @@
+package com.example.study.calendarproject.service;
+
+import com.example.study.calendarproject.domain.Schedule;
+import com.example.study.calendarproject.domain.constant.Category;
+import com.example.study.calendarproject.domain.constant.RepeatOption;
+import com.example.study.calendarproject.dto.ScheduleDto;
+import com.example.study.calendarproject.repository.ScheduleRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.*;
+
+/**
+ * 스케줄 생성
+ * 스케줄 수정
+ * 스케줄 삭제
+ * *** 이후에 할 것 ***
+ * 사용자 추가
+ * 초대링크 생성하기
+ */
+@ExtendWith(MockitoExtension.class)
+class ScheduleServiceTest {
+
+    @InjectMocks
+    private ScheduleService sut;  //System Under Test
+
+    @Mock
+    private ScheduleRepository scheduleRepository;
+
+
+    @DisplayName("스케줄 정보를 입력하면, 스케줄을 생성한다.")
+    @Test
+    void givenScheduleInfo_whenSavingSchedule_thenSaveSchedule() {
+        //Given
+        ScheduleDto dto = createScheduleDto();
+        given(scheduleRepository.save(any(Schedule.class))).willReturn(createSchedule());
+        //When
+        sut.saveSchedule(dto);
+
+        //Then
+        then(scheduleRepository).should().save(any(Schedule.class));
+    }
+
+    @DisplayName("스케줄의 수정정보를 입력하면, 스케줄을 수정한다.")
+    @Test
+    void givenModifiedSchduleInfo_whenUpdatingSchedule_thenUpdatesSchedule() {
+        //Given
+        Schedule schedule = createSchedule();
+        ScheduleDto dto = createScheduleDto();
+        given(scheduleRepository.getReferenceById(dto.getId())).willReturn(schedule);
+
+        //When
+        sut.updateSchedule(dto);
+
+        //Then
+        assertThat(schedule)
+                .hasFieldOrPropertyWithValue("name", dto.getName())
+                .hasFieldOrPropertyWithValue("location", dto.getLocation())
+                .hasFieldOrPropertyWithValue("category", dto.getCategory())
+                .hasFieldOrPropertyWithValue("start_time", dto.getStart_time())
+                .hasFieldOrPropertyWithValue("end_time", dto.getEnd_time())
+                .hasFieldOrPropertyWithValue("description", dto.getDescription())
+                .hasFieldOrPropertyWithValue("repeatOption", dto.getRepeatOption());
+        then(scheduleRepository).should().getReferenceById(dto.getId());
+    }
+
+    @DisplayName("스케줄의 ID를 입력하면, 스케줄을 삭제한다.")
+    @Test
+    void givenScheduleId_whenDeletingSchedule_thenDeletesSchedule() {
+        //Given
+        Long scheduleId = 1L;
+        willDoNothing().given(scheduleRepository).deleteById(scheduleId);
+
+        //When
+        sut.deleteSchedule(scheduleId);
+
+        //Then
+        then(scheduleRepository).should().deleteById(scheduleId);
+    }
+
+    private Schedule createSchedule() {
+        return Schedule.of("Open Session",
+                "경대 북문 블라인드 멜론",
+                Category.STUDY,
+                LocalDateTime.of(2022, 11, 20, 16, 30),
+                LocalDateTime.of(2022, 11, 20, 19, 30),
+                "정기 스터디 모임 활동",
+                RepeatOption.WEEK);
+    }
+
+    private ScheduleDto createScheduleDto() {
+        return createScheduleDto(
+                3L,
+                "private session",
+                "경북대학교 도서관",
+                Category.ETC,
+                LocalDateTime.of(2022, 11, 25, 16, 30),
+                LocalDateTime.of(2022, 11, 25, 19, 30),
+                "초청강연",
+                RepeatOption.DAY);
+    }
+
+    private ScheduleDto createScheduleDto(Long id, String name, String location, Category category, LocalDateTime start_time, LocalDateTime end_time, String description, RepeatOption repeatOption) {
+        return ScheduleDto.of(
+                id,
+                name,
+                location,
+                category,
+                start_time,
+                end_time,
+                description,
+                repeatOption
+        );
+    }
+
+}

--- a/src/test/java/com/example/study/calendarproject/service/ScheduleServiceTest.java
+++ b/src/test/java/com/example/study/calendarproject/service/ScheduleServiceTest.java
@@ -15,6 +15,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import java.time.LocalDateTime;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.*;
 
@@ -47,6 +48,26 @@ class ScheduleServiceTest {
 
         //Then
         then(scheduleRepository).should().save(any(Schedule.class));
+    }
+
+    @DisplayName("스케줄 정보 입력 도중 잘못된 시간 입력시(start_time이 end_time보다 늦을 경우) 예외를 발생시키고 메시지를 남긴다..")
+    @Test
+    void givenScheduleInfoWithIllegalTime_whenCreateSchedule_thenThrowException() {
+        Throwable t = catchThrowable(() -> createScheduleDto(
+                3L,
+                "private session",
+                "경북대학교 도서관",
+                Category.ETC,
+                LocalDateTime.of(2022, 11, 25, 20, 30),
+                LocalDateTime.of(2022, 11, 25, 19, 30),
+                "초청강연",
+                RepeatOption.DAY
+        ));
+
+        //Then
+        assertThat(t)
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("끝나는 시간이 시작 시간보다 빠를 수는 없습니다.");
     }
 
     @DisplayName("스케줄의 수정정보를 입력하면, 스케줄을 수정한다.")

--- a/src/test/java/com/example/study/calendarproject/service/ScheduleServiceTest.java
+++ b/src/test/java/com/example/study/calendarproject/service/ScheduleServiceTest.java
@@ -12,6 +12,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import javax.persistence.EntityNotFoundException;
 import java.time.LocalDateTime;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -26,6 +27,7 @@ import static org.mockito.BDDMockito.*;
  * *** 이후에 할 것 ***
  * 사용자 추가
  * 초대링크 생성하기
+ * User api 만들어졌으면 스케줄 조회 가능하도록 테스트
  */
 @ExtendWith(MockitoExtension.class)
 class ScheduleServiceTest {
@@ -72,7 +74,7 @@ class ScheduleServiceTest {
 
     @DisplayName("스케줄의 수정정보를 입력하면, 스케줄을 수정한다.")
     @Test
-    void givenModifiedSchduleInfo_whenUpdatingSchedule_thenUpdatesSchedule() {
+    void givenModifiedScheduleInfo_whenUpdatingSchedule_thenUpdatesSchedule() {
         //Given
         Schedule schedule = createSchedule();
         ScheduleDto dto = createScheduleDto();
@@ -90,6 +92,29 @@ class ScheduleServiceTest {
                 .hasFieldOrPropertyWithValue("end_time", dto.getEnd_time())
                 .hasFieldOrPropertyWithValue("description", dto.getDescription())
                 .hasFieldOrPropertyWithValue("repeatOption", dto.getRepeatOption());
+        then(scheduleRepository).should().getReferenceById(dto.getId());
+    }
+
+    @DisplayName("없는 스케줄의 수정정보를 입력하면, 경고 로고를 찍고 아무것도 하지 않는다.")
+    @Test
+    void givenNonexistentScheduleInfo_whenUpdatingSchedule_thenLogWarningAndDoesNothing() {
+        //Given
+        ScheduleDto dto = createScheduleDto(
+                3L,
+                "private session",
+                "경북대학교 도서관",
+                Category.ETC,
+                LocalDateTime.of(2022, 11, 25, 20, 30),
+                LocalDateTime.of(2022, 11, 25, 19, 30),
+                "초청강연",
+                RepeatOption.DAY
+        );
+        given(scheduleRepository.getReferenceById(dto.getId())).willThrow(EntityNotFoundException.class);
+
+        //When
+        sut.updateSchedule(dto);
+
+        //Then
         then(scheduleRepository).should().getReferenceById(dto.getId());
     }
 

--- a/src/test/java/com/example/study/calendarproject/service/ScheduleServiceTest.java
+++ b/src/test/java/com/example/study/calendarproject/service/ScheduleServiceTest.java
@@ -81,7 +81,7 @@ class ScheduleServiceTest {
         given(scheduleRepository.getReferenceById(dto.getId())).willReturn(schedule);
 
         //When
-        sut.updateSchedule(dto);
+        sut.updateSchedule(dto.getId(), dto);
 
         //Then
         assertThat(schedule)
@@ -104,7 +104,7 @@ class ScheduleServiceTest {
                 "private session",
                 "경북대학교 도서관",
                 Category.ETC,
-                LocalDateTime.of(2022, 11, 25, 20, 30),
+                LocalDateTime.of(2022, 11, 25, 10, 30),
                 LocalDateTime.of(2022, 11, 25, 19, 30),
                 "초청강연",
                 RepeatOption.DAY
@@ -112,7 +112,7 @@ class ScheduleServiceTest {
         given(scheduleRepository.getReferenceById(dto.getId())).willThrow(EntityNotFoundException.class);
 
         //When
-        sut.updateSchedule(dto);
+        sut.updateSchedule(dto.getId(), dto);
 
         //Then
         then(scheduleRepository).should().getReferenceById(dto.getId());


### PR DESCRIPTION
스케줄 관련 API 관련 기능을 구현하였다. 컨트롤러 구현까지는 Auditing이라던가, 유저의 정보가 필요하기 때문에 구현하지 않았다. 따라서 위의 기능이 추가된다면 다음번에 구현하도록 하겠다.

스케줄 관련 추가로 해야할 기능은
* 사용자 추가
* 초대 링크 생성하기
* 유저 api가 어느정도 완성된 후 조회가 가능하도록
* 스케줄 컨트롤러 구현